### PR TITLE
PR-0: Add read-only proxy endpoints & README

### DIFF
--- a/Controller/AlbumsController.cs
+++ b/Controller/AlbumsController.cs
@@ -1,0 +1,79 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SpotifyPlaylists.Controller;
+
+[ApiController]
+[Route("api/v1/albums")]
+public class AlbumsController : ControllerBase
+{
+    private readonly SpotifyClient _spotifyClient;
+    private readonly ILogger<AlbumsController> _logger;
+
+    public AlbumsController(SpotifyClient spotifyClient, ILogger<AlbumsController> logger)
+    {
+        _spotifyClient = spotifyClient;
+        _logger = logger;
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetAlbum(string id, [FromQuery] string? market, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetAlbum called with empty id.");
+            return BadRequest(new { error = "Album id is required." });
+        }
+
+        var query = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(market)) query["market"] = market;
+        var path = $"/v1/albums/{id}{ToQueryString(query)}";
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Album retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for album {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    [HttpGet("{id}/tracks")]
+    public async Task<IActionResult> GetAlbumTracks(string id, [FromQuery] string? market, [FromQuery] int? limit, [FromQuery] int? offset, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetAlbumTracks called with empty id.");
+            return BadRequest(new { error = "Album id is required." });
+        }
+
+        var query = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(market)) query["market"] = market;
+        if (limit.HasValue) query["limit"] = limit.Value.ToString();
+        if (offset.HasValue) query["offset"] = offset.Value.ToString();
+        var path = $"/v1/albums/{id}/tracks{ToQueryString(query)}";
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Album tracks retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for album tracks {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    private static string ToQueryString(Dictionary<string, string?> query)
+    {
+        var pairs = query.Where(kv => !string.IsNullOrEmpty(kv.Value)).Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}");
+        return pairs.Any() ? "?" + string.Join("&", pairs) : string.Empty;
+    }
+}

--- a/Controller/ArtistController.cs
+++ b/Controller/ArtistController.cs
@@ -37,4 +37,97 @@ public class ArtistController : ControllerBase
         Response.StatusCode = (int)apiResponse.StatusCode;
         return Content(content, "application/json");
     }
+
+    [HttpGet("{id}/albums")]
+    public async Task<IActionResult> GetArtistAlbums(string id, [FromQuery] string? market, [FromQuery] string? includeGroups, [FromQuery] int? limit, [FromQuery] int? offset, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetArtistAlbums called with empty id.");
+            return BadRequest(new { error = "Artist id is required." });
+        }
+
+        var query = BuildQuery(market, limit, offset);
+        if (!string.IsNullOrEmpty(includeGroups)) query["include_groups"] = includeGroups;
+        var path = $"/v1/artists/{id}/albums{ToQueryString(query)}";
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Artist albums retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for artist albums {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    [HttpGet("{id}/top-tracks")]
+    public async Task<IActionResult> GetArtistTopTracks(string id, [FromQuery] string? market, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetArtistTopTracks called with empty id.");
+            return BadRequest(new { error = "Artist id is required." });
+        }
+
+        var query = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(market)) query["market"] = market;
+        var path = $"/v1/artists/{id}/top-tracks{ToQueryString(query)}";
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Artist top tracks retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for artist top tracks {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    [HttpGet("{id}/related-artists")]
+    public async Task<IActionResult> GetRelatedArtists(string id, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetRelatedArtists called with empty id.");
+            return BadRequest(new { error = "Artist id is required." });
+        }
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest($"/v1/artists/{id}/related-artists", cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Related artists retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for related artists {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    private static Dictionary<string, string?> BuildQuery(string? market, int? limit, int? offset)
+    {
+        var q = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(market)) q["market"] = market;
+        if (limit.HasValue) q["limit"] = limit.Value.ToString();
+        if (offset.HasValue) q["offset"] = offset.Value.ToString();
+        return q;
+    }
+
+    private static string ToQueryString(Dictionary<string, string?> query)
+    {
+        if (query.Count == 0) return string.Empty;
+        var pairs = query.Where(kv => !string.IsNullOrEmpty(kv.Value)).Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}");
+        return "?" + string.Join("&", pairs);
+    }
 }

--- a/Controller/PlaylistsController.cs
+++ b/Controller/PlaylistsController.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SpotifyPlaylists.Controller;
+
+[ApiController]
+[Route("api/v1/playlists")]
+public class PlaylistsController : ControllerBase
+{
+    private readonly SpotifyClient _spotifyClient;
+    private readonly ILogger<PlaylistsController> _logger;
+
+    public PlaylistsController(SpotifyClient spotifyClient, ILogger<PlaylistsController> logger)
+    {
+        _spotifyClient = spotifyClient;
+        _logger = logger;
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetPlaylist(string id, [FromQuery] string? market, [FromQuery] string? fields, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetPlaylist called with empty id.");
+            return BadRequest(new { error = "Playlist id is required." });
+        }
+
+        var query = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(market)) query["market"] = market;
+        if (!string.IsNullOrWhiteSpace(fields)) query["fields"] = fields;
+        var path = $"/v1/playlists/{id}{ToQueryString(query)}";
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Playlist retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for playlist {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    [HttpGet("{id}/tracks")]
+    public async Task<IActionResult> GetPlaylistTracks(string id, [FromQuery] string? market, [FromQuery] string? fields, [FromQuery] int? limit, [FromQuery] int? offset, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetPlaylistTracks called with empty id.");
+            return BadRequest(new { error = "Playlist id is required." });
+        }
+
+        var query = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(market)) query["market"] = market;
+        if (!string.IsNullOrWhiteSpace(fields)) query["fields"] = fields;
+        if (limit.HasValue) query["limit"] = limit.Value.ToString();
+        if (offset.HasValue) query["offset"] = offset.Value.ToString();
+        var path = $"/v1/playlists/{id}/tracks{ToQueryString(query)}";
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Playlist tracks retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for playlist tracks {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    private static string ToQueryString(Dictionary<string, string?> query)
+    {
+        var pairs = query.Where(kv => !string.IsNullOrEmpty(kv.Value)).Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}");
+        return pairs.Any() ? "?" + string.Join("&", pairs) : string.Empty;
+    }
+}

--- a/Controller/SearchController.cs
+++ b/Controller/SearchController.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SpotifyPlaylists.Controller;
+
+[ApiController]
+[Route("api/v1")]
+public class SearchController : ControllerBase
+{
+    private readonly SpotifyClient _spotifyClient;
+    private readonly ILogger<SearchController> _logger;
+
+    public SearchController(SpotifyClient spotifyClient, ILogger<SearchController> logger)
+    {
+        _spotifyClient = spotifyClient;
+        _logger = logger;
+    }
+
+    [HttpGet("search")]
+    public async Task<IActionResult> Search(
+        [FromQuery] string? q,
+        [FromQuery] string? type,
+        [FromQuery] string? market,
+        [FromQuery] int? limit,
+        [FromQuery] int? offset,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(q))
+        {
+            _logger.LogWarning("Search called with empty q.");
+            return BadRequest(new { error = "Query parameter 'q' is required." });
+        }
+
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            _logger.LogWarning("Search called with empty type.");
+            return BadRequest(new { error = "Query parameter 'type' is required (e.g. artist,track,album,playlist)." });
+        }
+
+        var query = new Dictionary<string, string?>
+        {
+            ["q"] = q,
+            ["type"] = type
+        };
+        if (!string.IsNullOrWhiteSpace(market)) query["market"] = market;
+        if (limit.HasValue) query["limit"] = limit.Value.ToString();
+        if (offset.HasValue) query["offset"] = offset.Value.ToString();
+
+        var path = "/v1/search" + ToQueryString(query);
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Search completed: {Q}", q);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API search error: {StatusCode}", apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    private static string ToQueryString(Dictionary<string, string?> query)
+    {
+        var pairs = query.Where(kv => !string.IsNullOrEmpty(kv.Value)).Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}");
+        return pairs.Any() ? "?" + string.Join("&", pairs) : string.Empty;
+    }
+}

--- a/Controller/TracksController.cs
+++ b/Controller/TracksController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace SpotifyPlaylists.Controller;
+
+[ApiController]
+[Route("api/v1/tracks")]
+public class TracksController : ControllerBase
+{
+    private readonly SpotifyClient _spotifyClient;
+    private readonly ILogger<TracksController> _logger;
+
+    public TracksController(SpotifyClient spotifyClient, ILogger<TracksController> logger)
+    {
+        _spotifyClient = spotifyClient;
+        _logger = logger;
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetTrack(string id, [FromQuery] string? market, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+        {
+            _logger.LogWarning("GetTrack called with empty id.");
+            return BadRequest(new { error = "Track id is required." });
+        }
+
+        var query = new Dictionary<string, string?>();
+        if (!string.IsNullOrWhiteSpace(market)) query["market"] = market;
+        var path = $"/v1/tracks/{id}{ToQueryString(query)}";
+
+        using var apiResponse = await _spotifyClient.MakeAuthenticatedRequest(path, cancellationToken);
+        var content = await apiResponse.Content.ReadAsStringAsync(cancellationToken);
+
+        if (apiResponse.IsSuccessStatusCode)
+        {
+            _logger.LogDebug("Track retrieved: {Id}", id);
+            return Content(content, "application/json");
+        }
+
+        _logger.LogWarning("Spotify API error for track {Id}: {StatusCode}", id, apiResponse.StatusCode);
+        Response.StatusCode = (int)apiResponse.StatusCode;
+        return Content(content, "application/json");
+    }
+
+    private static string ToQueryString(Dictionary<string, string?> query)
+    {
+        var pairs = query.Where(kv => !string.IsNullOrEmpty(kv.Value)).Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}");
+        return pairs.Any() ? "?" + string.Join("&", pairs) : string.Empty;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,141 @@
+# LilyPlaylists
+
+A .NET 8 ASP.NET Core Web API that proxies read-only requests to the [Spotify Web API](https://developer.spotify.com/documentation/web-api). It handles OAuth (client credentials), token caching, and exposes search, artists, albums, tracks, and public playlists.
+
+## Prerequisites
+
+- [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- A [Spotify app](https://developer.spotify.com/dashboard) (Client ID and Client Secret)
+
+## Setup
+
+1. **Clone and restore**
+
+   ```bash
+   cd LilyPlaylists
+   dotnet restore
+   ```
+
+2. **Configure Spotify credentials**
+
+   Create a `config.json` in the project root (this file is gitignored):
+
+   ```json
+   {
+     "client_id": "YOUR_SPOTIFY_CLIENT_ID",
+     "client_secret": "YOUR_SPOTIFY_CLIENT_SECRET",
+     "token_url": "https://accounts.spotify.com/api/token"
+   }
+   ```
+
+   Or use [User Secrets](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets) / environment variables and set `client_id`, `client_secret`, and optionally `token_url` at the configuration root.
+
+3. **Run**
+
+   ```bash
+   dotnet run --project SpotifyPlaylists.csproj
+   ```
+
+   In Development, Swagger UI is available at `/swagger`.
+
+## API Endpoints
+
+Base path: **`api/v1`**. All proxy endpoints return Spotify’s JSON and mirror Spotify’s status codes.
+
+### Token
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/token` | Get an access token. Body: `{ "client_id": "...", "client_secret": "..." }`. |
+
+### Search
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/search` | Proxy to [Spotify Search](https://developer.spotify.com/documentation/web-api/reference/search). |
+
+**Query parameters**
+
+- **`q`** (required) – Search query.
+- **`type`** (required) – Comma-separated: `artist`, `track`, `album`, `playlist`.
+- **`market`** (optional)
+- **`limit`**, **`offset`** (optional)
+
+**Example:** `GET /api/v1/search?q=foo&type=artist,track`
+
+### Artists
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/artists/{id}` | Get artist by ID. |
+| `GET` | `/api/v1/artists/{id}/albums` | Get artist’s albums. Optional: `market`, `include_groups`, `limit`, `offset`. |
+| `GET` | `/api/v1/artists/{id}/top-tracks` | Get artist’s top tracks. Optional: `market`. |
+| `GET` | `/api/v1/artists/{id}/related-artists` | Get related artists. |
+
+### Albums
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/albums/{id}` | Get album by ID. Optional: `market`. |
+| `GET` | `/api/v1/albums/{id}/tracks` | Get album tracks. Optional: `market`, `limit`, `offset`. |
+
+### Tracks
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/tracks/{id}` | Get track by ID. Optional: `market`. |
+
+### Playlists (public only)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/playlists/{id}` | Get playlist by ID. Optional: `market`, `fields`. |
+| `GET` | `/api/v1/playlists/{id}/tracks` | Get playlist tracks. Optional: `market`, `fields`, `limit`, `offset`. |
+
+## Example requests
+
+```bash
+# Get token (body with your app credentials)
+curl -X POST http://localhost:5000/api/v1/token \
+  -H "Content-Type: application/json" \
+  -d '{"client_id":"YOUR_ID","client_secret":"YOUR_SECRET"}'
+
+# Search
+curl "http://localhost:5000/api/v1/search?q=beatles&type=artist,track"
+
+# Artist
+curl "http://localhost:5000/api/v1/artists/0OdUWJ0sBjDrqHygGUXeCF"
+
+# Artist top tracks
+curl "http://localhost:5000/api/v1/artists/0OdUWJ0sBjDrqHygGUXeCF/top-tracks?market=US"
+
+# Album and tracks
+curl "http://localhost:5000/api/v1/albums/4iV5W9uYEdYUVa79Axb7Rh"
+curl "http://localhost:5000/api/v1/albums/4iV5W9uYEdYUVa79Axb7Rh/tracks"
+
+# Track
+curl "http://localhost:5000/api/v1/tracks/3n3Ppam7vgaVa1iaRUc9Lp"
+
+# Playlist and tracks
+curl "http://localhost:5000/api/v1/playlists/37i9dQZEVXbMDoHDwVN2tF"
+curl "http://localhost:5000/api/v1/playlists/37i9dQZEVXbMDoHDwVN2tF/tracks"
+```
+
+(Replace host/port with your `launchSettings.json` or environment values.)
+
+## Project structure
+
+```
+LilyPlaylists/
+├── Controller/          # API controllers (artists, search, albums, tracks, playlists, token)
+├── Model/               # DTOs and config (OAuthConfig, TokenRequest, TokenResult)
+├── Services/            # Token caching (ISpotifyTokenService, SpotifyTokenService)
+├── SpotifyClient.cs     # Spotify API client (token + authenticated requests)
+├── Program.cs            # App setup, DI, config
+├── config.json          # Local OAuth config (gitignored)
+└── SpotifyPlaylists.csproj
+```
+
+## License
+
+Unlicense or your choice.


### PR DESCRIPTION
# Add read-only proxy endpoints & README

## Summary

Adds read-only proxy endpoints for Spotify Search, Albums, Tracks, and Playlists, extends Artist with albums/top-tracks/related-artists, and adds a project README with setup and API documentation.

## Changes

### New endpoints

All under **`api/v1`**; required params validated with `400`; responses proxy Spotify JSON and status codes.

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/v1/search` | Search. Required: `q`, `type`. Optional: `market`, `limit`, `offset`. |
| `GET` | `/api/v1/albums/{id}` | Album by ID. Optional: `market`. |
| `GET` | `/api/v1/albums/{id}/tracks` | Album tracks. Optional: `market`, `limit`, `offset`. |
| `GET` | `/api/v1/tracks/{id}` | Track by ID. Optional: `market`. |
| `GET` | `/api/v1/playlists/{id}` | Playlist by ID. Optional: `market`, `fields`. |
| `GET` | `/api/v1/playlists/{id}/tracks` | Playlist tracks. Optional: `market`, `fields`, `limit`, `offset`. |
| `GET` | `/api/v1/artists/{id}/albums` | Artist’s albums. Optional: `market`, `include_groups`, `limit`, `offset`. |
| `GET` | `/api/v1/artists/{id}/top-tracks` | Artist’s top tracks. Optional: `market`. |
| `GET` | `/api/v1/artists/{id}/related-artists` | Related artists. |

### Implementation

- **SearchController** – `GET api/v1/search`; builds query from `q`, `type`, and optional params; forwards to Spotify search.
- **AlbumsController** – `GET api/v1/albums/{id}` and `GET api/v1/albums/{id}/tracks` with optional query params.
- **TracksController** – `GET api/v1/tracks/{id}` with optional `market`.
- **PlaylistsController** – `GET api/v1/playlists/{id}` and `GET api/v1/playlists/{id}/tracks` with optional params.
- **ArtistController** – New actions: `albums`, `top-tracks`, `related-artists`; shared helpers for query building.

Pattern: inject `SpotifyClient` and `ILogger`; validate IDs/params; call `MakeAuthenticatedRequest(path, cancellationToken)`; return `Content(content, "application/json")` with Spotify’s status code; dispose `HttpResponseMessage` with `using var`.

### Documentation

- **README.md** – Prerequisites, setup (`config.json` / User Secrets), run instructions, full API table, example `curl` requests, and project structure.

## New / modified files

| Action    | Path |
|-----------|------|
| Added     | `Controller/SearchController.cs` |
| Added     | `Controller/AlbumsController.cs` |
| Added     | `Controller/TracksController.cs` |
| Added     | `Controller/PlaylistsController.cs` |
| Added     | `README.md` |
| Modified  | `Controller/ArtistController.cs` |

## Breaking changes

None. Existing endpoints unchanged.

## How to test

1. Ensure `config.json` (or User Secrets) has valid Spotify `client_id` and `client_secret`.
2. **Search:** `GET /api/v1/search?q=beatles&type=artist,track` → 200 and search JSON.
3. **Artist extras:** `GET /api/v1/artists/{id}/albums`, `.../top-tracks?market=US`, `.../related-artists` → 200 and Spotify JSON.
4. **Album:** `GET /api/v1/albums/{id}`, `GET /api/v1/albums/{id}/tracks` → 200 and Spotify JSON.
5. **Track:** `GET /api/v1/tracks/{id}` → 200 and Spotify JSON.
6. **Playlist:** `GET /api/v1/playlists/{id}`, `GET /api/v1/playlists/{id}/tracks` → 200 and Spotify JSON.
7. Invalid/missing required params (e.g. empty `id`, missing `q` or `type` on search) → 400 with error message.

## Checklist

- [x] Search, albums, tracks, playlists, and artist extras implemented.
- [x] Query params forwarded where applicable (market, limit, offset, etc.).
- [x] Validation and consistent response pattern; no new breaking changes.
- [x] README added with setup and API documentation.
